### PR TITLE
Add quiz editor and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ TODO
 - Vite
 - Firebase auth
 - Neon
+
+## Development
+
+Run `npm run server` to start the API backend. In another terminal run `npm run dev` to start the Vite dev server.

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,69 @@
+import express from 'express';
+import cors from 'cors';
+import {PrismaClient} from '@prisma/client';
+import admin from 'firebase-admin';
+
+admin.initializeApp({
+  credential: admin.credential.applicationDefault()
+});
+
+const prisma = new PrismaClient();
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+async function authMiddleware(req, res, next) {
+  const header = req.headers.authorization || '';
+  if (!header.startsWith('Bearer ')) return res.status(401).json({error: 'Missing token'});
+  try {
+    const token = header.split(' ')[1];
+    const decoded = await admin.auth().verifyIdToken(token);
+    req.user = decoded;
+    next();
+  } catch {
+    res.status(401).json({error: 'Invalid token'});
+  }
+}
+
+app.get('/api/quizzes', authMiddleware, async (req, res) => {
+  const quizzes = await prisma.quizzes.findMany({where: {owner_id: req.user.uid}});
+  res.json(quizzes);
+});
+
+app.get('/api/quizzes/:id', authMiddleware, async (req, res) => {
+  const quiz = await prisma.quizzes.findUnique({where: {quiz_id: req.params.id}});
+  res.json(quiz);
+});
+
+app.post('/api/quizzes', authMiddleware, async (req, res) => {
+  const {title, description, content} = req.body;
+  const quiz = await prisma.quizzes.create({data: {title, description, owner_id: req.user.uid, content}});
+  res.json(quiz);
+});
+
+app.put('/api/quizzes/:id', authMiddleware, async (req, res) => {
+  const {title, description, content} = req.body;
+  const quiz = await prisma.quizzes.update({where: {quiz_id: req.params.id}, data: {title, description, content}});
+  res.json(quiz);
+});
+
+app.delete('/api/quizzes/:id', authMiddleware, async (req, res) => {
+  await prisma.quizzes.delete({where: {quiz_id: req.params.id}});
+  res.json({success: true});
+});
+
+app.get('/api/quizzes/:id/export', authMiddleware, async (req, res) => {
+  const quiz = await prisma.quizzes.findUnique({where: {quiz_id: req.params.id}});
+  res.json(quiz?.content || {});
+});
+
+app.post('/api/quizzes/import', authMiddleware, async (req, res) => {
+  const {title, description, content} = req.body;
+  const quiz = await prisma.quizzes.create({data: {title, description, owner_id: req.user.uid, content}});
+  res.json(quiz);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`API running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node api/server.js"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",
@@ -15,6 +16,9 @@
     "clsx": "^2.1.1",
     "firebase": "^11.6.1",
     "prisma": "^6.9.0",
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "firebase-admin": "^12.0.0",
     "react": "^19.0.0",
     "react-confetti-explosion": "^2.1.2",
     "react-dom": "^19.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model quizzes {
   quiz_id         String       @id @db.Uuid
   title           String
   description     String?
+  content         Json?
   owner_id        String?      @db.Uuid
   shared_user_ids String[]     @db.Uuid
   created_at      DateTime     @default(now()) @db.Timestamp(6)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,8 @@ import QuestionPage from './pages/QuestionPage.tsx';
 import {QuizProvider} from './context/QuizContext';
 import SettingsPage from "./pages/SettingsPage.tsx";
 import TeamsPage from "./pages/TeamsPage.tsx";
+import QuizListPage from "./pages/QuizListPage.tsx";
+import EditQuizPage from "./pages/EditQuizPage.tsx";
 import {AuthGate} from "./auth/AuthGate.tsx";
 import NotFoundPage from './pages/NotFoundPage.tsx';
 import AccountPage from "./pages/AccountPage.tsx";
@@ -22,6 +24,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
                         <Route path="/settings" element={<SettingsPage />} />
                         <Route path="/teams" element={<TeamsPage />} />
                         <Route path="/account" element={<AccountPage />} />
+                        <Route path="/editor" element={<QuizListPage/>} />
+                        <Route path="/editor/:id" element={<EditQuizPage/>} />
                         <Route path="*" element={<NotFoundPage />} />
                     </Routes>
                 </QuizProvider>

--- a/src/pages/EditQuizPage.tsx
+++ b/src/pages/EditQuizPage.tsx
@@ -1,0 +1,78 @@
+import {useEffect, useState, ChangeEvent} from 'react';
+import {useNavigate, useParams} from 'react-router-dom';
+import {auth} from '../lib/firebase';
+import {FaArrowLeft} from 'react-icons/fa';
+
+type Content = any;
+
+export default function EditQuizPage() {
+  const {id} = useParams();
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [content, setContent] = useState<Content>({categories: []});
+
+  useEffect(() => {
+    const load = async () => {
+      if (id && id !== 'new') {
+        const token = await auth.currentUser?.getIdToken();
+        const res = await fetch(`/api/quizzes/${id}`, {headers:{Authorization:`Bearer ${token}`}});
+        if (res.ok) {
+          const q = await res.json();
+          setTitle(q.title);
+          setDescription(q.description || '');
+          setContent(q.content || {categories: []});
+        }
+      }
+    };
+    load();
+  }, [id]);
+
+  const save = async () => {
+    const token = await auth.currentUser?.getIdToken();
+    const body = JSON.stringify({title, description, content});
+    if (id === 'new') {
+      await fetch('/api/quizzes', {method: 'POST', headers:{'Content-Type':'application/json', Authorization:`Bearer ${token}`}, body});
+    } else {
+      await fetch(`/api/quizzes/${id}`, {method: 'PUT', headers:{'Content-Type':'application/json', Authorization:`Bearer ${token}`}, body});
+    }
+    navigate('/editor');
+  };
+
+  const handleImport = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      file.text().then(t => setContent(JSON.parse(t)));
+    }
+  };
+
+  const handleExport = () => {
+    const data = JSON.stringify(content, null, 2);
+    const url = URL.createObjectURL(new Blob([data], {type: 'application/json'}));
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${title || 'quiz'}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="min-h-screen p-8 text-black flex flex-col gap-4">
+      <h1 className="text-3xl font-bold">{id === 'new' ? 'Új quiz' : 'Quiz szerkesztése'}</h1>
+      <input className="border p-2" placeholder="Cím" value={title} onChange={e=>setTitle(e.target.value)} />
+      <textarea className="border p-2" placeholder="Leírás" value={description} onChange={e=>setDescription(e.target.value)} />
+      <textarea className="border p-2 h-64" value={JSON.stringify(content, null, 2)} onChange={e=>setContent(JSON.parse(e.target.value))} />
+      <div className="flex gap-2">
+        <button onClick={save} className="bg-blue-600 text-white px-3 py-2 rounded">Mentés</button>
+        <button onClick={handleExport} className="bg-green-600 text-white px-3 py-2 rounded">Export JSON</button>
+        <label className="bg-gray-200 px-3 py-2 rounded cursor-pointer">
+          Import JSON
+          <input type="file" accept="application/json" onChange={handleImport} className="hidden" />
+        </label>
+      </div>
+      <button onClick={()=>navigate('/editor')} className="absolute bottom-4 left-4 bg-gray-800 text-white p-3 rounded-full shadow-lg hover:bg-gray-700" aria-label="Back">
+        <FaArrowLeft size={20}/>
+      </button>
+    </div>
+  );
+}

--- a/src/pages/QuizListPage.tsx
+++ b/src/pages/QuizListPage.tsx
@@ -1,0 +1,47 @@
+import {useEffect, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {auth} from '../lib/firebase';
+import {FaArrowLeft} from 'react-icons/fa';
+
+export default function QuizListPage() {
+  const [quizzes, setQuizzes] = useState<any[]>([]);
+  const navigate = useNavigate();
+
+  const load = async () => {
+    const token = await auth.currentUser?.getIdToken();
+    const res = await fetch('/api/quizzes', {headers: {Authorization: `Bearer ${token}`}});
+    if (res.ok) setQuizzes(await res.json());
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const remove = async (id: string) => {
+    if (!confirm('Biztos törlöd?')) return;
+    const token = await auth.currentUser?.getIdToken();
+    await fetch(`/api/quizzes/${id}`, {method: 'DELETE', headers: {Authorization: `Bearer ${token}`}});
+    load();
+  };
+
+  return (
+    <div className="min-h-screen p-8 text-black">
+      <h1 className="text-3xl font-bold mb-6">Quizek</h1>
+      <button onClick={() => navigate('/editor/new')} className="mb-4 bg-blue-600 text-white px-3 py-2 rounded">
+        Új quiz
+      </button>
+      <ul className="space-y-2">
+        {quizzes.map(q => (
+          <li key={q.quiz_id} className="border p-2 flex justify-between">
+            <span>{q.title}</span>
+            <div className="flex gap-2">
+              <button onClick={() => navigate(`/editor/${q.quiz_id}`)} className="text-blue-600">Szerkesztés</button>
+              <button onClick={() => remove(q.quiz_id)} className="text-red-600">Törlés</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <button onClick={() => navigate('/')} className="absolute bottom-4 left-4 bg-gray-800 text-white p-3 rounded-full shadow-lg hover:bg-gray-700" aria-label="Back">
+        <FaArrowLeft size={20}/>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add express API server for quizzes backed by Prisma and firebase auth
- add content JSON field to prisma schema
- create quiz list and edit pages with import/export
- wire new routes
- document dev server in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845f6f8cd2c8322b6b162299ebeabd7